### PR TITLE
Display header tokens as well as meta tokens

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Test: Origin Trials Viewer",
+  "name": "Origin Trials Viewer",
   "short_name": "OT Viewer",
   "manifest_version": 2,
   "version": "0.0.1",

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Origin Trials Viewer",
+  "name": "Test: Origin Trials Viewer",
   "short_name": "OT Viewer",
   "manifest_version": 2,
   "version": "0.0.1",
@@ -13,7 +13,8 @@
     "64": "img/64.png"
   },
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "webRequest"
   ],
   "browser_action": {
     "default_icon": "img/64.png",

--- a/popup.html
+++ b/popup.html
@@ -13,6 +13,10 @@ body {
   padding: 4px;
 }
 
+.hidden {
+  display: none;
+}
+
 .token {
   font-size: 1rem;
   margin: 0;
@@ -102,6 +106,7 @@ footer {
     <h1 class=feature></h1>
     <dl>
       <dt class=origin>origin</dt       ><dd><a href=></a></dd>
+      <dt class=type>type</dt           ><dd></dd>
       <dt class=expiry>expiry</dt       ><dd><time datetime></time></dd>
       <dt class=subdomain>subdomain</dt ><dd></dd>
       <dt class=thirdparty>3rd Party</dt><dd></dd>
@@ -110,7 +115,7 @@ footer {
 </template>
 
 
-<div id=no-token>
+<div id=no-token class=hidden>
   No Origin Trials Token available on this page
 </div>
 

--- a/tab.js
+++ b/tab.js
@@ -1,5 +1,11 @@
 (function() {
-  const metas  = document.querySelectorAll('meta[http-equiv="origin-trial"]')
-  const tokens = Array.from(metas).map((meta) => meta.content)
-  return tokens
+  const metas  = document.querySelectorAll('meta[http-equiv="origin-trial"]');
+  const tokens = Array.from(metas).map((meta) => {
+		return {
+			type:'meta', 
+			value: meta.content,
+		};
+	});
+  return tokens;
 })()
+


### PR DESCRIPTION
• This works, but I've used a `setTimeout()` to wait until headers have been received, so it feels a bit hacky. It'd be better to wait until *all* responses headers have been received — maybe by waiting until page load or by using `chrome.tabs.onUpdated`? I'll have a go next week.

• Only one header token is displayed.

My code could probably do with some tweaking :).